### PR TITLE
Add simple digits classifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
 # codex
+
+This repository contains simple machine learning examples.
+
+## Digits classifier
+
+`digits_model.py` trains a logistic regression model on scikit-learn's digits dataset and reports accuracy.
+
+Run the script with:
+
+```bash
+python digits_model.py
+```
+
+Make sure `scikit-learn` is installed in your environment.
+

--- a/digits_model.py
+++ b/digits_model.py
@@ -1,0 +1,21 @@
+import numpy as np
+from sklearn.datasets import load_digits
+from sklearn.model_selection import train_test_split
+from sklearn.linear_model import LogisticRegression
+from sklearn.metrics import accuracy_score
+
+
+def main():
+    digits = load_digits()
+    X_train, X_test, y_train, y_test = train_test_split(
+        digits.data, digits.target, test_size=0.2, random_state=42
+    )
+    clf = LogisticRegression(max_iter=1000)
+    clf.fit(X_train, y_train)
+    y_pred = clf.predict(X_test)
+    acc = accuracy_score(y_test, y_pred)
+    print(f"Accuracy: {acc:.4f}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement digits classifier using scikit-learn
- document how to run the example

## Testing
- `python digits_model.py`

------
https://chatgpt.com/codex/tasks/task_e_686453eef9588324815c12f7a92f976a